### PR TITLE
let GetToolDAQ.sh install Root

### DIFF
--- a/GetToolDAQ.sh
+++ b/GetToolDAQ.sh
@@ -68,6 +68,7 @@ do
 	    boostflag=0
 	    zmq=0
 	    final=0
+	    rootflag=1
             ;;
 	
 	


### PR DESCRIPTION
Unlike all other variables, `rootflag` defaults to 0. So it’s not enough to set all others to 0, we need to explicitly set `rootflag` to 1 here, otherwise `./GetToolDAQ.sh --Root` exits without doing anything.